### PR TITLE
Add optional login parameter for autologin

### DIFF
--- a/bin/reconfig-local-drupal
+++ b/bin/reconfig-local-drupal
@@ -9,6 +9,7 @@ DEBUG=
 DRUSH_VERBOSITY='-q'
 CREATE=
 IGNORE_ERRORS=
+AUTOLOGIN=false
 
 print_usage() {
   echo
@@ -21,6 +22,7 @@ print_usage() {
   echo "  -c | --create-file-dir    Creates the 'files' (and 'private') directory if "
   echo "                             they are missing. By dedault it just warns."
   echo "  -f | --force              Continues even if an error occurs" 
+  echo "  -l | --login              Automatic Login"
   echo
 }
 
@@ -71,6 +73,7 @@ while true; do
 
     -c | --create-file-dir )  CREATE=true; shift;;
     -f | --force )            IGNORE_ERRORS=true; shift;;
+    -l | --login )            AUTOLOGIN=true; shift;;
 
     -- ) shift; break ;;
     * ) break ;;
@@ -147,7 +150,9 @@ print_message notice "Enabling Development Modules"
 print_message notice "Clean sessions table"
 `$drush_cmd sql-query 'TRUNCATE TABLE sessions;'`
 
-print_message notice "Loggin into the local site"
-echo `$drush_cmd user-login 1`
+if $AUTOLOGIN; then
+  print_message notice "Loggin into the local site"
+  echo `$drush_cmd user-login 1`
+fi
 
 print_message OK "Command completed!"


### PR DESCRIPTION
Hi, 

I thought it might be usefull to only login to the site if you tell the script to do so. So I added `-l | --login`parameter. If not set no login is performed. 
- I changed the way I use the uli command on my machine so I can use `|pbcopy` it does not work with that script ;)
- Also if you write batch scripts and use your tool, you might dont want to run the login

Greetings
Alexander
